### PR TITLE
Force pymongo version 2.7.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 django==1.4.13
 django-tastypie==0.9.11
 django-celery-with-mongodb
-pymongo
+pymongo==2.7.2
 requests
 django-extensions
 django-uni-form


### PR DESCRIPTION
`from pymongo import Connection` is deprecated. To avoid issues with newer pymongo versions, 2.7.2 is forced to avoid numerous issues.